### PR TITLE
Patch build_env.py

### DIFF
--- a/build/build_env.py
+++ b/build/build_env.py
@@ -24,7 +24,7 @@ class BuildRequest(build_utils.BuildRequest):
     def __get_system_libs(self):
         platform = self.platform_
         platform_name = platform.name()
-        arch = platform.arch()
+        arch = platform.architecture()
         dep_libs = []
 
         if platform_name == 'linux':


### PR DESCRIPTION
The `Platform.arch` method has been renamed to `Platform.architecture`.

See 
- https://github.com/fastogt/pyfastogt/blob/f0051aed64d6e80177834b3483b71385b051fe1e/pyfastogt/system_info.py#L33
- https://github.com/fastogt/pyfastogt/commit/7cb098f123d752027668e015326608ff20046c06#diff-1c11cd7b0346dd1ff00b82cd44c4e2d1R31